### PR TITLE
Added two integration hooks

### DIFF
--- a/services/ExportService.php
+++ b/services/ExportService.php
@@ -23,6 +23,20 @@ class ExportService extends BaseApplicationComponent
     private $_service;
 
     /**
+     * Custom <tr> paths.
+     *
+     * @var array
+     */
+    public $customTableRowPaths = array();
+
+    /**
+     * Whether custom table row paths have been loaded.
+     *
+     * @var bool
+     */
+    private $_loadedTableRowPaths = false;
+
+    /**
      * Saves an export map to the database.
      *
      * @param array $settings
@@ -161,6 +175,42 @@ class ExportService extends BaseApplicationComponent
 
             // Return this service
             return craft()->$service;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get path to fieldtype's custom <tr> template.
+     *
+     * @param string $fieldHandle
+     *
+     * @return string
+     */
+    public function getCustomTableRow($fieldHandle)
+    {
+        // If table row paths haven't been loaded
+        if (!$this->_loadedTableRowPaths) {
+
+            // Call hook for all plugins
+            $responses = craft()->plugins->call('registerExportTableRowPaths');
+
+            // Loop through responses from each plugin
+            foreach ($responses as $customPaths) {
+
+                // Append custom paths to master list
+                $this->customTableRowPaths = array_merge($this->customTableRowPaths, $customPaths);
+            }
+
+            // Table row paths have been loaded
+            $this->_loadedTableRowPaths = true;
+        }
+
+        // If fieldtype has been registered and is not falsey
+        if (array_key_exists($fieldHandle, $this->customTableRowPaths) && $this->customTableRowPaths[$fieldHandle]) {
+
+            // Return specified custom path
+            return $this->customTableRowPaths[$fieldHandle];
         }
 
         return false;

--- a/services/Export_CategoryService.php
+++ b/services/Export_CategoryService.php
@@ -70,7 +70,7 @@ class Export_CategoryService extends BaseApplicationComponent implements IExport
             // Set the dynamic fields for this type
             foreach (craft()->fields->getLayoutByType(ElementType::Category)->getFields() as $field) {
                 $data = $field->getField();
-                $fields[$data->handle] = array('name' => $data->name, 'checked' => 1);
+                $fields[$data->handle] = array('name' => $data->name, 'checked' => 1, 'fieldtype' => $data->type);
             }
         } else {
 
@@ -119,7 +119,11 @@ class Export_CategoryService extends BaseApplicationComponent implements IExport
         // Try to parse checked fields through prepValue
         foreach ($map as $handle => $data) {
             if ($data['checked']) {
-                $attributes[$handle] = $element->$handle;
+                try {
+                    $attributes[$handle] = $element->$handle;
+                } catch (\Exception $e) {
+                    $attributes[$handle] = null;
+                }
             }
         }
 
@@ -136,6 +140,9 @@ class Export_CategoryService extends BaseApplicationComponent implements IExport
                 $attributes[ExportModel::HandleAncestors] = implode('/', $element->getAncestors()->find());
             }
         }
+
+        // Call hook allowing 3rd-party plugins to modify attributes
+        craft()->plugins->call('modifyExportAttributes', array(&$attributes, $element));
 
         return $attributes;
     }

--- a/services/Export_UserService.php
+++ b/services/Export_UserService.php
@@ -91,7 +91,7 @@ class Export_UserService extends BaseApplicationComponent implements IExportElem
             // Set the dynamic fields for this type
             foreach (craft()->fields->getLayoutByType(ElementType::User)->getFields() as $field) {
                 $data = $field->getField();
-                $fields[$data->handle] = array('name' => $data->name, 'checked' => 1);
+                $fields[$data->handle] = array('name' => $data->name, 'checked' => 1, 'fieldtype' => $data->type);
             }
         } else {
 
@@ -140,9 +140,16 @@ class Export_UserService extends BaseApplicationComponent implements IExportElem
         // Try to parse checked fields through prepValue
         foreach ($map as $handle => $data) {
             if ($data['checked']) {
-                $attributes[$handle] = $element->$handle;
+                try {
+                    $attributes[$handle] = $element->$handle;
+                } catch (\Exception $e) {
+                    $attributes[$handle] = null;
+                }
             }
         }
+
+        // Call hook allowing 3rd-party plugins to modify attributes
+        craft()->plugins->call('modifyExportAttributes', array(&$attributes, $element));
 
         return $attributes;
     }

--- a/templates/_map.twig
+++ b/templates/_map.twig
@@ -30,8 +30,16 @@
 
         <table class="data sortable">
             <tbody>
-        {% set fields = craft.export.getFields(export.type, reset) %}
-        {% for handle, data in fields %}
+    {% set fields = craft.export.getFields(export.type, reset) %}
+    {% for handle, data in fields %}
+        {% if data.fieldtype is defined %}
+            {% set customTableRow = craft.export.customTableRow(data.fieldtype) %}
+        {% else %}
+            {% set customTableRow = false %}
+        {% endif %}
+        {% if customTableRow %}
+            {% include customTableRow ignore missing %}
+        {% else %}
             <tr>
                 <td>
                     <div class="field">
@@ -59,7 +67,8 @@
                     }) }}
                 </td>
             </tr>
-        {% endfor %}
+        {% endif %}
+    {% endfor %}
             </tbody>
             <tfoot>
                 <tr>

--- a/variables/ExportVariable.php
+++ b/variables/ExportVariable.php
@@ -79,4 +79,17 @@ class ExportVariable
 
         return false;
     }
+
+    /**
+     * Get path to fieldtype's custom table row template.
+     *
+     * @param string $fieldHandle
+     *
+     * @return string
+     */
+    public function customTableRow($fieldHandle)
+    {
+        // Return custom <tr> for template
+        return craft()->export->getCustomTableRow($fieldHandle);
+    }
 }


### PR DESCRIPTION
Hey Bob, this pull request adds two new hooks for 3rd party plugin integration...

---

**modifyExportAttributes**

This allows another plugin to perform any "final cleanup" on the data before it's exported to CSV.

It's triggered in the following service files:

 - `services/Export_EntryService.php`
 - `services/Export_CategoryService.php`
 - `services/Export_UserService.php`

---

**registerExportTableRowPaths**

This hook provides the ability to customize the table row of the field being exported. Here's an example of how Smart Map is using it to split a single "Address" field into multiple CSV columns...

<img width="675" alt="custom-tr" src="https://cloud.githubusercontent.com/assets/5309692/10265260/ef8c756c-69dd-11e5-934b-e4a5c2de553c.png">

The files making this possible are:

 - `templates/_map.twig` (calls the `customTableRow` variable)
 - `variables/ExportVariable.php` (pass through to `getCustomTableRow` service method)
 - `services/ExportService.php` (triggers the hook)

---

Thanks man, let me know if you have any questions or feedback!