### PR TITLE
Set category fieldmap based on selected group

### DIFF
--- a/services/Export_CategoryService.php
+++ b/services/Export_CategoryService.php
@@ -68,10 +68,13 @@ class Export_CategoryService extends BaseApplicationComponent implements IExport
             );
 
             // Set the dynamic fields for this type
-            foreach (craft()->fields->getLayoutByType(ElementType::Category)->getFields() as $field) {
-                $data = $field->getField();
-                $fields[$data->handle] = array('name' => $data->name, 'checked' => 1, 'fieldtype' => $data->type);
+            if( $group = craft()->categories->getGroupById( $settings["elementvars"]["group"] ) ){
+                foreach (craft()->fields->getLayoutById( $group->fieldLayoutId )->getFields() as $field) {
+                    $data = $field->getField();
+                    $fields[$data->handle] = array('name' => $data->name, 'checked' => 1, 'fieldtype' => $data->type);
+                }
             }
+
         } else {
 
             // Get the stored map


### PR DESCRIPTION
With multiple category field layouts, there can be a mismatch between the expected fields and the fields set in the map. The current code appears to always grab the first fieldLayout from the db.

This fix explicitly takes the selected groups fieldLayout to populate the fieldmap.